### PR TITLE
Avoid notice from Heroku 16

### DIFF
--- a/lib/ruby_tika_app.rb
+++ b/lib/ruby_tika_app.rb
@@ -24,7 +24,7 @@ class RubyTikaApp
 
     java_cmd = 'java'
     java_args = '-server -Djava.awt.headless=true'
-    tika_path = "#{File.join(File.dirname(__FILE__))}/../ext/tika-app-1.14.jar"
+    tika_path = "#{File.join(File.dirname(__FILE__))}/../ext/tika-app-1.9.jar"
 
     @tika_cmd = "#{java_cmd} #{java_args} -jar '#{tika_path}'"
   end

--- a/lib/ruby_tika_app.rb
+++ b/lib/ruby_tika_app.rb
@@ -76,7 +76,10 @@ class RubyTikaApp
   end
 
   def strip_stderr(s)
-    s.gsub(/^(info|warn) - .*$/i, '').strip
+    s
+      .gsub(/^(info|warn) - .*$/i, '')
+      .strip
+      .gsub(/Picked up JAVA_TOOL_OPTIONS: .+ -Dfile.encoding=UTF-8/i, '')
+      .strip
   end
-
 end


### PR DESCRIPTION
On Heroku 16, when we run the Java process, it shows a notice that which option it picked

![screen shot 2017-11-28 at 12 46 26 pm](https://user-images.githubusercontent.com/11751745/33304233-3549093a-d43a-11e7-83b0-9480ca6f5a7f.png)

And the way we are doing is expect the stderr, if (the first line of the response from Java process) if it present this gem assume that the process has an error.

![screen_shot_2017-11-28_at_12_13_42_pm](https://user-images.githubusercontent.com/11751745/33306600-cb134966-d445-11e7-858a-6ba535974d81.png)

But at here, the message from Java process is not an error, it just a notice, so we have to bypass this notice.