### PR TITLE
Handle stderr output

### DIFF
--- a/lib/ruby_tika_app.rb
+++ b/lib/ruby_tika_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Based on the rake remote task code
 
 require 'rubygems'
@@ -5,6 +7,8 @@ require 'stringio'
 require 'open4'
 
 class RubyTikaApp
+  TIKA_APP_VERSION = '1.22'
+
   class Error < RuntimeError; end
 
   class CommandFailedError < Error
@@ -24,7 +28,7 @@ class RubyTikaApp
     java_cmd = 'java'
     java_args = '-server -Djava.awt.headless=true'
     ext_dir = File.join(File.dirname(__FILE__))
-    tika_path = "#{ext_dir}/../ext/tika-app-1.19.1.jar"
+    tika_path = "#{ext_dir}/../ext/tika-app-#{TIKA_APP_VERSION}.jar"
     tika_config_path = "#{ext_dir}/../ext/tika-config.xml"
 
     @tika_cmd = "#{java_cmd} #{java_args} -jar '#{tika_path}' --config='#{tika_config_path}'"

--- a/lib/ruby_tika_app.rb
+++ b/lib/ruby_tika_app.rb
@@ -68,7 +68,7 @@ class RubyTikaApp
     stdout_result = stdout.read.strip
     stderr_result = stderr.read.strip
 
-    unless strip_stderr(stderr_result).empty?
+    if stdout_result.empty? && !stderr_result.empty?
       raise(CommandFailedError.new(stderr_result),
             "execution failed with status #{stderr_result}: #{final_cmd}")
     end
@@ -78,13 +78,5 @@ class RubyTikaApp
     stdin.close
     stdout.close
     stderr.close
-  end
-
-  def strip_stderr(err)
-    err
-      .gsub(/^(info|warn) - .*$/i, '')
-      .strip
-      .gsub(/Picked up JAVA_TOOL_OPTIONS: .+ -Dfile.encoding=UTF-8/i, '')
-      .strip
   end
 end

--- a/spec/ruby_tika_app_spec.rb
+++ b/spec/ruby_tika_app_spec.rb
@@ -19,6 +19,15 @@ describe RubyTikaApp do
     end
   end
 
+  describe 'CommandFailedError' do
+    it 'is raised correctly' do
+      expect do
+        rta = RubyTikaApp.new('/file_not_found.pdf')
+        rta.to_text
+      end.to raise_error(RubyTikaApp::CommandFailedError)
+    end
+  end
+
   describe '#to_xml' do
     it 'header' do
       rta = RubyTikaApp.new(@test_file)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 # Start a local rack server to serve up test pages.
 @server_thread = Thread.new do
-  Rack::Handler::Thin.run MyApp::Test::Server.new, Port: 9299
+  Rack::Handler::Thin.run(MyApp::Test::Server.new, Port: 9299, Host: '127.0.0.1')
 end
 
 sleep(1) # wait a sec for the server to be booted


### PR DESCRIPTION
### Problem

We have no control over what different environments output in `stderr`. For example on Heroku, this gets added by default:

```
Picked up JAVA_TOOL_OPTIONS: -Xmx300m -Xss512k -XX:CICompilerCount=2 -Dfile.encoding=UTF-8
```

On top of that, if you enable `runtime-heroku-metrics` in Heroku labs, you'll also add this to the output:

```
/app/.heroku/bin/heroku-metrics-agent.jar
```

and if you enable `runtime-heroku-exec` in labs, you'll also get this:

```
-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1098 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=true -Djava.rmi.server.hostname=172.19.37.106 -Djava.rmi.server.port=1099
```

Just logging, no errors. As a result of this, every attempt to parse a PDF results in `CommandFailedError`.

### Solution

Given this information, it's impossible to pattern-match error output to strip out known logs that are not errors.

This PR proposes to simplify things by raising an error if `stdout` is empty while `stderr` is not. For our use case this works great, but please let me know if there are known cases where it won't work well.

### Other changes

1. Bump Tika App to `1.22`
1. Add `Host` to `Rack::Handler::Thin` options to make specs testing external URLs pass (wouldn't work without it, I'm on macOS Mojave).

Most likely resolves #10 
